### PR TITLE
Fix: Touch ENV File in foreground

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Demo made by [Richard He](https://twitter.com/RealRichomie)
 
 - There are limited web crawling features, with buttons and input fields sometimes failing to appear in prompt.
 - The response time is slow, with each action taking between 1-10 seconds to run.
-- At times, langchain agents are unable to parse GPT outputs (refer to langchain discussion: https://github.com/hwchase17/langchain/discussions/4065). If you run into this, try specifying a different agent; ie: `python -m chromegpt -a auto-gpt -v -t "{your request}"
+- At times, langchain agents are unable to parse GPT outputs (refer to langchain discussion: https://github.com/hwchase17/langchain/discussions/4065). If you run into this, try specifying a different agent; ie: `python -m chromegpt -a auto-gpt -v -t "{your request}"`
 
 <h2 align="center"> Requirements </h2>
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Options:
 
 Or Just update .env and
 
-`source .env & docker-compose up`
+`source .env && docker-compose up`
 
 <h2 align="center"> ⭐ Star History </h2>
 


### PR DESCRIPTION
The docker command is sourcing the ENV file in the background before running `docker-compose`. This gets the job done but can have weird side effects. I think the original author meant to use `&&` versus `&`, there's a big difference (one runs the process in the background and the other runs it in the foreground first, then the sequential command)

I also fixed a small formatting issue